### PR TITLE
Prevent usage of unsafe numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var InvalidConfigurationError = require('./errors/invalid-configuration-error');
 var MalformedRangeError = require('./errors/malformed-range-error');
 var RangeNotSatisfiableError = require('./errors/range-not-satisfiable-error');
 var contentRangeFormat = require('http-content-range-format');
+var isSafeInteger = require('is-safe-integer');
 var rangeSpecifierParser = require('range-specifier-parser');
 
 /**
@@ -27,7 +28,7 @@ module.exports = function(options) {
     var unit = options.unit;
 
     // Prevent invalid `maximum` value configuration.
-    if (!_.isFinite(maximum) || maximum <= 0) {
+    if (!_.isFinite(maximum) || !isSafeInteger(maximum) || maximum <= 0) {
       throw new InvalidConfigurationError();
     }
 
@@ -47,6 +48,10 @@ module.exports = function(options) {
       first = range.first;
       last = range.last;
       unit = range.unit;
+
+      if (!isSafeInteger(first) || !isSafeInteger(last)) {
+        throw new RangeNotSatisfiableError();
+      }
     }
 
     // Prevent pages to be longer than allowed.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "create-error": "0.3.1",
     "debug": "2.1.0",
     "http-content-range-format": "1.0.0",
+    "is-safe-integer": "^1.0.1",
     "lodash": "2.4.1",
     "range-specifier-parser": "0.1.0",
     "util": "0.10.3"

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -98,6 +98,17 @@ describe('paginate', function() {
       .end();
   });
 
+  it('should give and error if `maximum` is not a safe integer', function *() {
+    var app = koa();
+
+    app.use(paginate({ maximum: 9007199254740993 }));
+
+    yield request(app.listen())
+      .get('/')
+      .expect(500)
+      .end();
+  });
+
   it('should accept a `Range` header', function *() {
     var app = koa();
 
@@ -178,6 +189,30 @@ describe('paginate', function() {
     yield request(app.listen())
       .get('/')
       .set('Range', 'items=11-11')
+      .expect(416)
+      .end();
+  });
+
+  it('should give and error if `first position` is not a safe integer', function *() {
+    var app = koa();
+
+    app.use(paginate());
+
+    yield request(app.listen())
+      .get('/')
+      .set('Range', 'items=9007199254740992-9007199254740993')
+      .expect(416)
+      .end();
+  });
+
+  it('should give and error if `last position` is not a safe integer', function *() {
+    var app = koa();
+
+    app.use(paginate());
+
+    yield request(app.listen())
+      .get('/')
+      .set('Range', 'items=1-9007199254740992')
       .expect(416)
       .end();
   });


### PR DESCRIPTION
This adds an extra security layer as prevents the usage of [unsafe](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) numbers.